### PR TITLE
Do not print the url in requests

### DIFF
--- a/bitcoinica.py
+++ b/bitcoinica.py
@@ -55,7 +55,6 @@ class Bitcoinica:
 				req = urllib2.Request(url)
        			else:	
 				req.add_data(urllib.urlencode(kwargs))
-		print url
 		if auth:
     			auth = 'Basic ' + base64.urlsafe_b64encode("%s:%s" % (self.user, self.password))
     			req.add_header('Authorization', auth)


### PR DESCRIPTION
The URL is printed for every request. The library should not print
anything. Remove the print statement.
